### PR TITLE
(fix): typo metabox field Lattitude -> Latitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 4.1.3
+
+-   Fix: typo metabox field Lattitude -> Latitude
+
 ## Version 4.1.2
 
 -   Refactor: hide taxonomies from quick edit menu

--- a/config/metaboxes.php
+++ b/config/metaboxes.php
@@ -41,7 +41,7 @@ return [
                 ],
                 [
                     'name' => __('Termijnoverschrijding', OWO_LANGUAGE_DOMAIN),
-                    'id'=> 'woo_Termijnoverschrijding',
+                    'id' => 'woo_Termijnoverschrijding',
                     'type' => 'select',
                     'options' => [
                         '' => '',
@@ -200,7 +200,7 @@ return [
                             'type' => 'text',
                         ],
                         [
-                            'name' => __('Lattitude', OWO_LANGUAGE_DOMAIN),
+                            'name' => __('Latitude', OWO_LANGUAGE_DOMAIN),
                             'id'   => 'woo_Lattitude',
                             'type' => 'text',
                         ],

--- a/languages/openwoo-nl_NL.po
+++ b/languages/openwoo-nl_NL.po
@@ -138,7 +138,7 @@ msgid "Longitude"
 msgstr ""
 
 #: config/openwoo/metaboxes.php:261
-msgid "Lattitude"
+msgid "Latitude"
 msgstr ""
 
 #: config/openwoo/metaboxes.php:268

--- a/languages/openwoo.pot
+++ b/languages/openwoo.pot
@@ -139,7 +139,7 @@ msgid "Longitude"
 msgstr ""
 
 #: config/openwoo/metaboxes.php:261
-msgid "Lattitude"
+msgid "Latitude"
 msgstr ""
 
 #: config/openwoo/metaboxes.php:268

--- a/openwoo.php
+++ b/openwoo.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Plugin Name:       Yard | OpenWOO
  * Plugin URI:        https://www.yard.nl/
  * Description:       Adds OpenWOO implementation
- * Version:           4.1.2
+ * Version:           4.1.3
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0
@@ -30,7 +30,7 @@ define('OWO_SLUG', basename(__FILE__, '.php'));
 define('OWO_LANGUAGE_DOMAIN', OWO_SLUG);
 define('OWO_DIR', basename(__DIR__));
 define('OWO_ROOT_PATH', __DIR__);
-define('OWO_VERSION', '4.1.2');
+define('OWO_VERSION', '4.1.3');
 
 /**
  * Manual loaded file: the autoloader.

--- a/src/OpenWOO/Models/GeografischePositieEntity.php
+++ b/src/OpenWOO/Models/GeografischePositieEntity.php
@@ -1,10 +1,12 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Yard\OpenWOO\Models;
 
 class GeografischePositieEntity extends AbstractEntity
 {
-    protected array $required = ['Longitude', 'Lattitude'];
+    protected array $required = ['Longitude', 'Latitude'];
 
     protected function data(): array
     {
@@ -14,7 +16,7 @@ class GeografischePositieEntity extends AbstractEntity
 
         return [
             'Longitude' => ! empty($this->data[self::PREFIX . 'Longitude']) ? (float) $this->data[self::PREFIX . 'Longitude'] : '',
-            'Lattitude' => ! empty($this->data[self::PREFIX . 'Lattitude']) ? (float) $this->data[self::PREFIX . 'Lattitude'] : '',
+            'Latitude' => ! empty($this->data[self::PREFIX . 'Lattitude']) ? (float) $this->data[self::PREFIX . 'Lattitude'] : '',
         ];
     }
 }


### PR DESCRIPTION
Barry,

Dank voor je PR, ik heb hem deels overgenomen. Als we ook het ID veranderen gaan OpenWOO items die nog gebruik maken van het oude ID onderuit. Eventueel kunnen we hier nog een commando voor schrijven die van alle OpenWOO items dit veld aanpast van `woo_Lattitude` naar `woo_Latitude`. 