### PR TITLE
fix WOOVerzoeken typo

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -95,7 +95,7 @@ components:
         repository: {}
         Response:
             properties:
-                WOOverzoeken:
+                WOOVerzoeken:
                     type: array
                     items:
                         $ref: "#/components/schemas/OpenWOO"

--- a/src/OpenWOO/RestAPI/ItemController.php
+++ b/src/OpenWOO/RestAPI/ItemController.php
@@ -110,7 +110,7 @@ class ItemController
         $items = (new OpenWOORepository())
             ->query(apply_filters('yard/openwoo/rest-api/items/query', $this->getPaginatorParams($request)))
             ->query(apply_filters('yard/openwoo/rest-api/items/query', $this->getFilters($request)));
-        
+
         if ($this->showOnParamIsValid($request)) {
             $items->query(OpenWOORepository::addShowOnParameter($request->get_param('source')));
         }
@@ -118,7 +118,7 @@ class ItemController
         $data = $items->all();
 
         return new Response([
-            'WOOverzoeken' => $data
+            'WOOVerzoeken' => $data
         ], $items->getQuery());
     }
 
@@ -195,7 +195,7 @@ class ItemController
         }
 
         return new Response([
-            'WOOverzoeken' => [
+            'WOOVerzoeken' => [
                 $data
             ]
         ], $item->getQuery());

--- a/src/OpenWOO/RestAPI/Response.php
+++ b/src/OpenWOO/RestAPI/Response.php
@@ -12,7 +12,7 @@ class Response extends WP_REST_Response
 {
     /**
      * @OA\Property(
-     *   property="WOOverzoeken",
+     *   property="WOOVerzoeken",
      *   type="array",
      *   @OA\Items(ref="#/components/schemas/OpenWOO"),
      *   @OA\Link(link="OpenWOORepository", ref="#/components/links/OpenWOORepository")


### PR DESCRIPTION
Deze PR fixt een typo in de API specs en ItemController. Op dit moment zijn we geforceerd om WooVerzoeken verkeerd te spellen in onze API specs, omdat de ItemController specifiek naar "Wooverzoeken" op zoek is. 

Wanneer we "Wooverzoeken" gebruiken in onze API specs in plaats van camelcase "WooVerzoeken" dan krijg je een WOOItemList model met verkeerde namen:

![Screenshot 2023-08-24 at 17 07 11](https://github.com/OpenWebconcept/plugin-openwoo/assets/67947342/0e0a4abd-446f-44c2-b8db-2ac58f1fd10b)

Op dit moment lossen we dit zelf op met een patch, maar het is netter om dit in de plugin al te fixen voor toekomstige gemeentes.

Let op, als je dit aanpast is het wel een breaking change in de plugin.

Groetjes,
Ken
Level Level