### PR TITLE
Use the samenvatting field instead with post excerpt as fallback

### DIFF
--- a/src/OpenWOO/Models/OpenWOO.php
+++ b/src/OpenWOO/Models/OpenWOO.php
@@ -49,7 +49,7 @@ class OpenWOO
             'Volgnummer'                  => $this->meta('Volgnummer', ''),
             'Titel'                       => $this->meta('Onderwerp', ''),
             'Beschrijving'                => $this->field('post_content', ''),
-            'Samenvatting'                => $this->field('post_excerpt', ''),
+            'Samenvatting'                => $this->meta('Samenvatting', '') ?: $this->field('post_excerpt', ''),
             'Verzoeker'                   => $this->meta('Verzoeker', ''),
             'Ontvangstdatum'              => $this->meta('Ontvangstdatum') ? $this->transformToEnglishDateFormat($this->meta('Ontvangstdatum')) : '',
             'Besluitdatum'                => $this->meta('Besluitdatum') ? $this->transformToEnglishDateFormat($this->meta('Besluitdatum')) : '',
@@ -187,7 +187,7 @@ class OpenWOO
         if (! is_null($default) && gettype($data) !== gettype($default)) {
             return $default;
         }
-    
+
         return $data;
     }
 


### PR DESCRIPTION
Er is op een WOO post een Samenvatting veld aanwezig, maar deze wordt op dit moment niet gebruikt door de plugin. De plugin pakt de post_excerpt die helemaal onderaan de WOO velden staat, dat is nog verwarrend voor de gebruiker.

Deze PR zorgt er voor dat eerst het Samenvatting veld van de plugin wordt gebruikt en de post_excerpt als fallback.

Groetjes,
Ken
Level Level