### PR TITLE
add missing fields that are need by elasticpress in the search queries

### DIFF
--- a/src/OpenWOO/ElasticPress/OpenWOOIndexable.php
+++ b/src/OpenWOO/ElasticPress/OpenWOOIndexable.php
@@ -112,6 +112,8 @@ class OpenWOOIndexable extends Post
             'post_mime_type'        => $post->post_mime_type,
             'permalink'             => \get_permalink($post_id),
             'meta'                  => $this->prepare_meta_types($this->prepare_meta($post)), // post_meta removed in 2.4
+			'post_title'			=> $post->post_title,
++			'post_status'			=> $post->post_status,
         ];
 
         // Turn back on updated_postmeta hook


### PR DESCRIPTION
Deze PR voegt 2 velden toe die nodig zijn wanneer je gebruik maakt van de ElasticPress plugin. Anders worden WOO items geïndexeerd zonder post_title en post_status, deze gebruikt ElasticPress in de search queries.

Groetjes,
Ken
Level Level